### PR TITLE
Fix patch for CakePHP 4 & set _method POST parameter as fixed

### DIFF
--- a/cakefuzzer/instrumentation/patches/cakephp/4/vendor/cakephp/authentication/src/AuthenticationService.php.patch
+++ b/cakefuzzer/instrumentation/patches/cakephp/4/vendor/cakephp/authentication/src/AuthenticationService.php.patch
@@ -1,5 +1,5 @@
---- AuthenticationService.php.orig	2023-01-06 15:21:59.538516455 +0000
-+++ AuthenticationService.php	2023-01-06 15:35:13.732502489 +0000
+--- AuthenticationService.php.orig	2023-04-19 14:23:51.483136657 +0000
++++ AuthenticationService.php	2023-04-19 14:24:04.883001093 +0000
 @@ -20,6 +20,7 @@
  use Authentication\Authenticator\AuthenticatorInterface;
  use Authentication\Authenticator\ImpersonationInterface;
@@ -25,7 +25,7 @@
          $result = null;
          /** @var \Authentication\Authenticator\AuthenticatorInterface $authenticator */
          foreach ($this->authenticators() as $authenticator) {
-@@ -203,6 +207,36 @@
+@@ -203,6 +207,34 @@
  
          return $this->_result = $result;
      }
@@ -52,8 +52,6 @@
 +        else $result = new Result($user, Result::SUCCESS);
 +
 +        if ($result->isValid()) {
-+            $this->_successfulAuthenticator = $authenticator;
-+
 +            return $this->_result = $result;
 +        }
 +

--- a/cakefuzzer/phpfiles/AppInstrument.php
+++ b/cakefuzzer/phpfiles/AppInstrument.php
@@ -49,6 +49,8 @@ class MagicPayloadDictionary implements JsonSerializable {
     protected $_global_probability = null;
     protected $_injected = null;
     protected $_payload_types = array();
+    public $original = null;
+    public $parameters = null;
     public function __construct(
             $name,
             $prefix='',
@@ -441,6 +443,7 @@ class AppInstrument {
         if(empty($_SERVER['REQUEST_METHOD'])) {
             $methods = array('GET', 'POST');
             $_SERVER['REQUEST_METHOD'] = $methods[array_rand($methods)];
+            if($_SERVER['REQUEST_METHOD'] == "POST") $_POST["_method"] = "POST";
         }
 
         # Assign Accept header if not provided. TODO: Move to different part of the code.
@@ -553,6 +556,8 @@ class AppInstrument {
                         else $original = $$global;
                         $prefix = 'HTTP_';
                         break;
+                    default:
+                        if(!empty($$global)) $original = $$global;
                 }
 
                 if($files) $$global = new AccessLoggingArray('_FILES');

--- a/precheck.sh
+++ b/precheck.sh
@@ -38,6 +38,6 @@ if [ ! -e venv ]; then
 fi
 source venv/bin/activate
 
-pip3 install -qr requirements.txt
+sudo pip3 install -qr requirements.txt
 
 echo "setup finished!"


### PR DESCRIPTION
# Description
- Fix CakePHP patch
- Set `_method` POST parameter to POST (it shouldn't be targeted in attacks)
- Fix precheck

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:
* CakePHP version: 4.4.9
* Application name: Cerebrate
* Application version: 1.13

# Checklist:

- [X] PR title contains the nature of changes (Docs, Feature, Fix, CI, etc.)
- [ ] I've set corresponding reviewers, set assignees, and labels.
- [X] My code follows the style guidelines of this project (running `pre-commit`)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
