### PR TITLE
[Feature] DNS monitor

### DIFF
--- a/cake_fuzzer.py
+++ b/cake_fuzzer.py
@@ -16,6 +16,7 @@ from cakefuzzer.domain.components import (
 from cakefuzzer.instrumentation.info_retriever import AppInfo
 from cakefuzzer.instrumentation.instrumentator import Instrumentator
 from cakefuzzer.instrumentation.route_computer import RouteComputer
+from cakefuzzer.scanners.dns import PhraseDnsScanner
 from cakefuzzer.scanners.filecontents import PhraseFileContentsScanner
 from cakefuzzer.scanners.iteration_result import (
     ResultErrorsScanner,
@@ -321,6 +322,7 @@ async def start_others() -> None:
                         "ProcessOutputScanner": ProcessOutputScanner,
                         "PhraseFileContentsScanner": PhraseFileContentsScanner,
                         "ResultErrorsScanner": ResultErrorsScanner,
+                        "PhraseDnsScanner": PhraseDnsScanner,
                     }
                     kwargs = {
                         "phrase": scanner.phrase,
@@ -397,6 +399,7 @@ async def my_start_others() -> None:
                         "ProcessOutputScanner": ProcessOutputScanner,
                         "PhraseFileContentsScanner": PhraseFileContentsScanner,
                         "ResultErrorsScanner": ResultErrorsScanner,
+                        "PhraseDnsScanner": PhraseDnsScanner,
                     }
                     kwargs = {
                         "phrase": scanner.phrase,

--- a/cakefuzzer/scanners/dns.py
+++ b/cakefuzzer/scanners/dns.py
@@ -34,7 +34,7 @@ class PhraseDnsScanner(DnsScanner):
 
         for vulnerability in vulnerabilities:
             print(
-                "Found in file????",
+                "Found DNS request",
                 vulnerability.detection_result,
                 vulnerability.payload_guid,
             )

--- a/cakefuzzer/scanners/dns.py
+++ b/cakefuzzer/scanners/dns.py
@@ -1,0 +1,41 @@
+import time
+
+from cakefuzzer.attacks.executor import AttackScenario
+from cakefuzzer.domain.interfaces import QueuePut
+from cakefuzzer.domain.scanners import DnsScanner
+from cakefuzzer.domain.vulnerability import VulnerabilitiesAdd
+from cakefuzzer.scanners.utils import VulnerabilityBuilder
+
+
+class PhraseDnsScanner(DnsScanner):
+    phrase: str
+    payload_guid_phrase: str
+    is_regex: bool = False
+
+    async def scan(
+        self,
+        scenario_queue: QueuePut[AttackScenario],
+        registry: VulnerabilitiesAdd,
+        domain: str,
+    ) -> None:
+        # TODO: this should be turned off when found something it's interested in
+
+        vulnerability_builder = VulnerabilityBuilder(
+            phrase=self.phrase,
+            string=domain,
+            payload_guid_phrase=self.payload_guid_phrase,
+            is_regex=self.is_regex,
+        )
+        vulnerabilities = vulnerability_builder.get_vulnerability_objects(
+            timestamp=time.time(),
+            scanner_id=hash(self),
+            iteration_result_id=None,  # We cannot get it now, have to wait...
+        )
+
+        for vulnerability in vulnerabilities:
+            print(
+                "Found in file????",
+                vulnerability.detection_result,
+                vulnerability.payload_guid,
+            )
+            await registry.add(vulnerability)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==0.21.0
 aiosqlite==0.17.0
 persist-queue==0.8.0
 progress==1.6
+scapy==2.5.0

--- a/strategies/ssrf.json
+++ b/strategies/ssrf.json
@@ -1,0 +1,13 @@
+{
+    "strategy_name": "SSRFAttackStrategy",
+    "scenarios": [
+        "http://4glkaunm0gijcgqvo1tfp5617sdj19py.§CAKEFUZZER_PAYLOAD_GUID§.local"
+    ],
+    "scanners": [
+        {
+            "scanner_type": "PhraseDnsScanner",
+            "phrase": "4glkaunm0gijcgqvo1tfp5617sdj19py.§CAKEFUZZER_PAYLOAD_GUID§.local",
+            "is_regex": true
+        }
+    ]
+}


### PR DESCRIPTION
# Description

We're adding DNS Scanner and Monitor to the `periodic_monitors` (`python cake_fuzzer.py run periodic_monitors`)
Using scapy library we're looking for outgoing dns calls and when that happens compare with all scanner definitions in db.

To add DNS Phrase Scanner add and/or modify the following definition to desired `.json` strategy file.
```
        {
            "scanner_type": "PhraseDnsScanner",
            "phrase": "google.com",
            "is_regex": false
        }
```
regex works as it does with other scanners (the logic is the same)

## Notes
To scan dns traffic the monitor has to be run with `root` privilege. Eg.
```
sudo python cake_fuzzer.py run periodic_monitors
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Yes. Added simple scanner (google.com) to the definitions in `strategies` and accessed the website. Results found int the registry meaning that the scanner picked up the DNS request.

# Checklist:

- [x] PR title contains the nature of changes (Docs, Feature, Fix, CI, etc.)
- [x] I've set corresponding reviewers, set assignees, and labels.
- [x] My code follows the style guidelines of this project (running `pre-commit`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
