### PR TITLE
Feature/scan all php files

### DIFF
--- a/cake_fuzzer.py
+++ b/cake_fuzzer.py
@@ -286,8 +286,6 @@ async def start_others() -> None:
         log_paths = await app_info.log_paths
         cake_path = await app_info.cakephp_path
 
-        # paths = ["Cerebrates/index"]
-
         for definition in defs:
             attacks = [
                 AttackScenario(

--- a/cake_fuzzer.py
+++ b/cake_fuzzer.py
@@ -3,7 +3,7 @@ import itertools
 import re
 from enum import Enum
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import typer
 
@@ -73,7 +73,7 @@ def add_fuzzable_actions(actions):
 
 async def compute_paths(
     webroot: Path, only_paths_with_prefix: str, exclude_pattern: str
-) -> List[str]:
+) -> Dict[str, List[str]]:
     app_info = AppInfo(webroot)
     return await app_info.paths
 
@@ -288,7 +288,9 @@ async def start_others() -> None:
             exclude_pattern=settings.exclude_paths,
         )
         total_paths = sum(len(paths[php_file]) for php_file in paths)
-        print(f"discovered {len(paths)} files to scan with total of {total_paths} paths")
+        print(
+            f"discovered {len(paths)} files to scan with total of {total_paths} paths"
+        )
 
         app_info = AppInfo(settings.webroot_dir)
         log_paths = await app_info.log_paths
@@ -307,7 +309,9 @@ async def start_others() -> None:
                         total_iterations=32,
                         payload_guid_phrase=settings.payload_guid_phrase,
                     )
-                    for payload, path in itertools.product(definition.scenarios, paths[php_file])
+                    for payload, path in itertools.product(
+                        definition.scenarios, paths[php_file]
+                    )
                 ]
 
             scanners = []

--- a/cake_fuzzer.py
+++ b/cake_fuzzer.py
@@ -75,6 +75,13 @@ async def compute_paths(
     webroot: Path, only_paths_with_prefix: str, exclude_pattern: str
 ) -> List[str]:
     app_info = AppInfo(webroot)
+    return await app_info.paths
+
+
+async def compute_paths_old(
+    webroot: Path, only_paths_with_prefix: str, exclude_pattern: str
+) -> List[str]:
+    app_info = AppInfo(webroot)
     # regexes = await app_info.routes
     # as per discussion in
     # https://github.com/Zigrin-Security/CakeFuzzer/pull/26#issuecomment-1320510117
@@ -280,25 +287,28 @@ async def start_others() -> None:
             only_paths_with_prefix=settings.only_paths_with_prefix,
             exclude_pattern=settings.exclude_paths,
         )
-        print(f"generated {len(paths)} paths")
+        total_paths = sum(len(paths[php_file]) for php_file in paths)
+        print(f"discovered {len(paths)} files to scan with total of {total_paths} paths")
 
         app_info = AppInfo(settings.webroot_dir)
         log_paths = await app_info.log_paths
         cake_path = await app_info.cakephp_path
 
         for definition in defs:
-            attacks = [
-                AttackScenario(
-                    cake_path=cake_path,
-                    webroot_file=str(settings.index_php),
-                    strategy_name=definition.strategy_name,
-                    payload=payload,
-                    path=path,
-                    total_iterations=32,
-                    payload_guid_phrase=settings.payload_guid_phrase,
-                )
-                for payload, path in itertools.product(definition.scenarios, paths)
-            ]
+            attacks = []
+            for php_file in paths:
+                attacks += [
+                    AttackScenario(
+                        cake_path=cake_path,
+                        webroot_file=str(php_file),
+                        strategy_name=definition.strategy_name,
+                        payload=payload,
+                        path=path,
+                        total_iterations=32,
+                        payload_guid_phrase=settings.payload_guid_phrase,
+                    )
+                    for payload, path in itertools.product(definition.scenarios, paths[php_file])
+                ]
 
             scanners = []
 

--- a/cakefuzzer/instrumentation/info_retriever.py
+++ b/cakefuzzer/instrumentation/info_retriever.py
@@ -52,6 +52,13 @@ class AppInfo:
         return output
 
     @property
+    async def paths(self) -> List[str]:
+        """
+        Call '$ app_info.php get_paths'.
+        """
+        return await self._call_app_info(["get_paths"])  # type: ignore
+
+    @property
     async def routes(self) -> List[str]:
         """
         Call '$ app_info.php get_routes'.

--- a/cakefuzzer/instrumentation/info_retriever.py
+++ b/cakefuzzer/instrumentation/info_retriever.py
@@ -52,7 +52,7 @@ class AppInfo:
         return output
 
     @property
-    async def paths(self) -> List[str]:
+    async def paths(self) -> Dict[str, List[str]]:
         """
         Call '$ app_info.php get_paths'.
         """

--- a/cakefuzzer/phpfiles/AppInfo.php
+++ b/cakefuzzer/phpfiles/AppInfo.php
@@ -4,6 +4,7 @@ class AppInfo {
     private $_command = "";
     private $_output_format = null;
     private $_app_handler = null;
+    private $_web_root = "";
     private $_index_path = "";
     private $_app_vars = array();
 
@@ -17,6 +18,7 @@ class AppInfo {
 
         // Parse index
         $this->_index_path = $this->_getIndex($_SERVER['argv'][1]);
+        $this->_web_root = $_SERVER['argv'][1];
 
         // Parse output format
         $this->_output_format = "json";
@@ -148,7 +150,7 @@ class AppInfo {
             return array(
                 'get_routes', 'get_controllers', 'get_components',
                 'get_actions', 'get_controllers_actions_arguments', 'get_plugins',
-                'get_log_paths', 'get_users', 'get_db_info', 'get_cakephp_info'
+                'get_log_paths', 'get_users', 'get_db_info', 'get_cakephp_info', 'get_paths'
             );
         }
         return array_keys($this->_app_handler->available_commands);

--- a/cakefuzzer/phpfiles/FrameworkHandler.php
+++ b/cakefuzzer/phpfiles/FrameworkHandler.php
@@ -13,6 +13,7 @@ class FrameworkHandler {
     }
 
     public function getFrameworkVersion() {
+        // Consider using Configure::version()
         $framework_path = $this->_framework_path ? $this->_framework_path : CORE_PATH;
         $cake_version = "";
         $version_path = $this->_searchFileInDir($framework_path, 'VERSION.txt');

--- a/cakefuzzer/phpfiles/frameworks/cakephp/2/TargetAppHandler.php
+++ b/cakefuzzer/phpfiles/frameworks/cakephp/2/TargetAppHandler.php
@@ -15,7 +15,7 @@ class TargetAppHandler extends CakePHPHandler {
             'get_plugins' => '_GetAllPluginsCommand',
             'get_components' => '_GetAllComponentsCommand',
             'get_actions' => '_GetAllActionsCommand',
-            'get_controllers_actions_arguments' => '_getControllersActionsArgumentsCommand',
+            'get_controllers_actions_arguments' => '_GetControllersActionsArgumentsCommand',
             'get_log_paths' => '_GetLogPathsCommand',
             'get_users' => '_GetUsersCommand',
             'get_db_info' => '_GetDBInfoCommand'
@@ -143,7 +143,7 @@ class TargetAppHandler extends CakePHPHandler {
             // var_dump($route->defaults['controller']);
             $str_routes[] = $route->compile();
         }
-        $str_routes = array_unique($str_routes);
+        $str_routes = array_values(array_unique($str_routes));
         return $str_routes;
     }
 
@@ -214,7 +214,7 @@ class TargetAppHandler extends CakePHPHandler {
      * 
      * @return array
      */
-    protected function _getControllersActionsArgumentsCommand() {
+    protected function _GetControllersActionsArgumentsCommand() {
         $all_info = array();
         $controllers = $this->_GetAllControllersCommand();
         foreach($controllers as $controller) {

--- a/cakefuzzer/phpfiles/frameworks/cakephp/4/TargetAppHandler.php
+++ b/cakefuzzer/phpfiles/frameworks/cakephp/4/TargetAppHandler.php
@@ -21,7 +21,7 @@ class TargetAppHandler extends CakePHPHandler {
             'get_plugins' => '_GetAllPluginsCommand',
             'get_components' => '_GetAllComponentsCommand',
             'get_actions' => '_GetAllActionsCommand',
-            'get_controllers_actions_arguments' => '_getControllersActionsArgumentsCommand',
+            'get_controllers_actions_arguments' => '_GetControllersActionsArgumentsCommand',
             'get_log_paths' => '_GetLogPathsCommand',
             'get_users' => '_GetUsersCommand',
             'get_db_info' => '_GetDBInfoCommand'
@@ -141,7 +141,7 @@ class TargetAppHandler extends CakePHPHandler {
      * 
      * @return array
      */
-    protected function _getControllersActionsArgumentsCommand() {
+    protected function _GetControllersActionsArgumentsCommand() {
         $all_info = array();
         $controllers = $this->_GetAllControllersCommand();
         foreach($controllers as $controller) {

--- a/cakefuzzer/phpfiles/frameworks/cakephp/CakePHPHandler.php
+++ b/cakefuzzer/phpfiles/frameworks/cakephp/CakePHPHandler.php
@@ -1,7 +1,7 @@
 <?php
 class CakePHPHandler {
     public $executed = false;
-    public $available_commands = array('get_cakephp_info'=>'_GetCakePHPInfoCommand');
+    public $available_commands = array('get_cakephp_info'=>'_GetCakePHPInfoCommand', 'get_paths'=>'_GetPathsCommand');
     protected $_command = "";
     protected $_cake_version = "";
     protected $_app_vars = array();
@@ -28,7 +28,7 @@ class CakePHPHandler {
         }
         $this->executed = true;
 
-        if($this->_command === 'get_cakephp_info') return $this->{$this->available_commands[$this->_command]}();
+        if(in_array($this->_command, array_keys($this->available_commands))) return $this->{$this->available_commands[$this->_command]}();
         if(!in_array($this->_command, array_keys($this->available_commands))) return $this->_CommandNotFound($this->_command);
 
         // Check if all CakePHP components are properly loaded
@@ -119,6 +119,176 @@ class CakePHPHandler {
             'app_root_dir' => ROOT
         );
         return $info;
+    }
+
+    /**
+     * To be overwritten by the child class
+     */
+    protected function _GetRoutesAsStringsCommand() {
+        return array();
+    }
+
+    /**
+     * To be overwritten by the child class
+     */
+    protected function _GetControllersActionsArgumentsCommand() {
+        return array();
+    }
+
+    /**
+     * Get dict of PHP files with paths to be scanned
+     */
+    protected function _GetPathsCommand() {
+        $php_files = $this->_searchFilesInDir(WWW_ROOT, '.php');
+        $paths = array();
+        foreach($php_files as $file) {
+            $paths[$file] = $this->_getPathsFromPHPFile($file);
+        }
+        return $paths;
+    }
+
+    private function _searchFilesInDir($directory, $extension) {
+        $dir = new RecursiveDirectoryIterator($directory);
+        $ite = new RecursiveIteratorIterator($dir);
+        $regPattern = "@$directory.*".str_replace(".","\.",$extension)."@";
+        $files = new RegexIterator($ite, $regPattern, RegexIterator::GET_MATCH);
+        $fileList = array();
+        foreach($files as $file) {
+            $fileList = array_merge($fileList, $file);
+        }
+        return array_unique($fileList);
+    }
+
+    protected function _getPathsFromPHPFile($file) {
+        $result = array();
+        if(basename($file) === "index.php") {
+            $results[] = "/";
+            $routes = $this->_GetRoutesAsStringsCommand();
+            $controllers = $this->_GetControllersActionsArgumentsCommand();
+            // $plugins = $this->_GetAllPluginsCommand();
+            $routes = array($routes[count($routes)-1]); // Dev Temp. To do: Remove
+            foreach($routes as $route) {
+                if($route[0] === $route[-1]) $route = substr($route, 1, -1); // Removing regex markers
+                if($route[0] === "^") $route = substr($route, 1); // Removing route beginning
+                if($route[-1] === "$") $route = substr($route, 0, -1); // Removng route ending
+
+                $matchPattern = "/(?:((?:\[[\w\/]+\](?:[\+\*])?)|\([\w|]+\))\??|(\w\?)|(\(\?:\/?\(\?P<(controller|action|_args_|plugin|id)>[^\)]+\)\)\??))/";
+
+                $route = preg_replace_callback("/(\(|\|)(\w+)(?:\(([\w\|]+)\)\??)/", function($array){
+                    $output = explode("|", $array[3]);
+                    if ($array[0][-1] === "?") {
+                        $output[] = "";
+                    }
+                    foreach ($output as &$option) {
+                        $option = $array[2] . $option;
+                    }
+                    return $array[1] . implode("|", $output);
+                }, $route);
+
+
+                preg_match_all($matchPattern, $route, $matches);
+
+                // Detect match group indexes of controller, action, and args
+                $indexes = array("controller", "action", "_args_");
+                $controller_index = $action_index = -1;
+                foreach($indexes as $index) {
+                    $i_name = $index."_index";
+                    $$i_name = -1;
+                    for($i=0;$i<count($matches[0]);++$i) if(strpos($matches[0][$i], "<$index>") !== false) {
+                        $$i_name = $i;
+                        break;
+                    }
+                }
+
+                $expanded_routes = $this->_expandControllerActionsInRoute(
+                    $route,
+                    $matches[0][$controller_index],
+                    $matches[0][$action_index],
+                    $matches[0][$_args__index],
+                    $controllers
+                );
+                // Removing controller and action matches for further processing
+                // They were replaced already in _expandControllerActionsInRoute
+                for($i=0;$i<count($matches);++$i) {
+                    unset($matches[$i][$controller_index]);
+                    unset($matches[$i][$action_index]);
+                    unset($matches[$i][$_args__index]);
+                }
+                foreach($expanded_routes as $expanded_route) {
+                    // Expands the () and [] and ? parts of the regular expressions
+                    $result = array_merge($result, $this->_getMatches(
+                        $expanded_route,
+                        $this->_prepOptions($matches[0]),
+                        $matchPattern,
+                        $controllers
+                    ));
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Takes regex and creates all possible combinations of it replacing
+     * controllers and actions. It doesn't touch the rest of the regex.
+     * 
+     * To do: Find a way to add fuzzable controller and action
+     */
+    private function _expandControllerActionsInRoute($pattern, $controllerMatch, $actionMatch, $argsMatch, $controllers) {
+        $new_patterns = array();
+        foreach($controllers as $controller => $actions) {
+            foreach($actions as $action => $params) {
+                $tmp_pattern = str_replace($controllerMatch, $controller, $pattern);
+                $tmp_pattern = str_replace($actionMatch, $action, $tmp_pattern);
+                if(!empty($params)) {
+                    for($i=0;$i<count($params);++$i) {
+                        // The slash below is a hack assuming this method knows the structure of the URL paths.
+                        $tmp_pattern = str_replace($argsMatch, "/_CAKE_FUZZER_FUZZABLE_".$params[$i]['position']."_".$argsMatch, $tmp_pattern);
+                    }
+                }
+                $tmp_pattern = str_replace($argsMatch, "", $tmp_pattern);
+                $new_patterns[] = $tmp_pattern;
+            }
+        }
+        return $new_patterns;
+    }
+
+    private function _getMatches($pattern, $array, $matchPattern) {
+        $currentArray = array_shift($array);
+        $result = array();
+
+        foreach ($currentArray as $option) {
+            $patternModified = preg_replace($matchPattern, $option, $pattern, 1);
+            if (!count($array)) {
+                // echo $patternModified, PHP_EOL;
+                $result[] = $patternModified;
+            } else {
+                $result = array_merge($result, $this->_getMatches($patternModified, $array, $matchPattern));
+            }
+        }
+        return $result;
+    }
+
+    private function _prepOptions($matches)
+    {
+        foreach ($matches as $match) {
+            $cleanString = preg_replace("/[\[\]\(\)\?\+\*]/", "", $match);
+            
+            if ($match[0] === "[") {
+                $array = str_split($cleanString, 1);
+            } elseif ($match[0] === "(") {
+                $array = explode("|", $cleanString);
+            } else {
+                $array = [$cleanString];
+            }
+            // Treat + * the same way as ?
+            // Don't do it if the only char in the match is /
+            if ($cleanString !== "/" && in_array($match[-1], array("?", "+", "*"))) {
+                $array[] = "";
+            }
+            $possibilites[] = $array;
+        }
+        return $possibilites;
     }
 
     /**

--- a/cakefuzzer/phpfiles/frameworks/cakephp/CakePHPHandler.php
+++ b/cakefuzzer/phpfiles/frameworks/cakephp/CakePHPHandler.php
@@ -162,7 +162,6 @@ class CakePHPHandler {
     protected function _getPathsFromPHPFile($file) {
         $result = array();
         if(basename($file) === "index.php") {
-            $results[] = "/";
             $routes = $this->_GetRoutesAsStringsCommand();
             $controllers = $this->_GetControllersActionsArgumentsCommand();
             // $plugins = $this->_GetAllPluginsCommand();
@@ -224,6 +223,9 @@ class CakePHPHandler {
                     ));
                 }
             }
+        }
+        else {
+            $result[] = "/";
         }
         return $result;
     }

--- a/cakefuzzer/settings/instrumentation.py
+++ b/cakefuzzer/settings/instrumentation.py
@@ -31,7 +31,7 @@ class GlobFunctionOverrideInstrumentation(BaseModel):
                 new_function_name=self.new_function_name,
                 semaphore=semaphore,
             )
-            for pathname in glob.glob(self.glob, recursive=True)
+            for pathname in glob.glob(self.glob, recursive=True) if os.path.isfile(pathname)
         ]
 
         contains = await asyncio.gather(

--- a/config/instrumentation_cake4.ini
+++ b/config/instrumentation_cake4.ini
@@ -2,7 +2,7 @@ PATCH_DIR="cakefuzzer/instrumentation/patches"
 OVERRIDES='
 [
     {
-        "glob": "${APP_DIR}/**/*.php",
+        "glob": "${APP_DIR}/../**/*.php",
         "function_name": "header",
         "new_function_name": "__cakefuzzer_header"
     }

--- a/precheck.sh
+++ b/precheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-sudo apt update
+sudo apt -qq update
 
 commands=(patch sed python3-pip)
 python_ver=$(whereis python3 | grep -Eo 'python3\.[0-9]+ ' | sort -u | tail -n 1|xargs)


### PR DESCRIPTION
# Description
- Path generation moved to PHP code. `app_info.php` has new command: `get_paths`
- Detection and scanning of all PHP files in the web root directory


## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* CakePHP version: 4.4.9
* Application name: Cerebrate
* Application version: 1.13

# Checklist:

- [X] PR title contains the nature of changes (Docs, Feature, Fix, CI, etc.)
- [X] I've set corresponding reviewers, set assignees, and labels.
- [ ] My code follows the style guidelines of this project (running `pre-commit`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
