### PR TITLE
[Feature] Extract iteration result based on the payload found in output instead of requester

### DIFF
--- a/cakefuzzer/domain/components.py
+++ b/cakefuzzer/domain/components.py
@@ -399,22 +399,24 @@ class VulnerabilitiesRegistry:
 
             if vuln.iteration_result is None:
                 dump_vuln = {
-                    "strategy_name": None,
-                    "payload": payload,
-                    "detection_result": vuln.vulnerability.detection_result,
-                    "context_location": vuln.vulnerability.context_location,
-                    "vulnerability_location": vuln.vulnerability_location,
-                    "vulnerability_id": i,
-                    "path": None,
-                    "method": None,
-                    "superglobal": {
-                        "_GET": None,
-                        "_POST": None,
-                        "_REQUEST": None,
-                        "_COOKIE": None,
-                        "_FILES": None,
-                        "_SERVER": None,
-                    },
+                    "found_in":{
+                        "strategy_name": None,
+                        "payload": payload,
+                        "detection_result": vuln.vulnerability.detection_result,
+                        "context_location": vuln.vulnerability.context_location,
+                        "vulnerability_location": vuln.vulnerability_location,
+                        "vulnerability_id": i,
+                        "path": None,
+                        "method": None,
+                        "superglobal": {
+                            "_GET": None,
+                            "_POST": None,
+                            "_REQUEST": None,
+                            "_COOKIE": None,
+                            "_FILES": None,
+                            "_SERVER": None,
+                        },
+                    }
                 }
 
             else:

--- a/cakefuzzer/domain/components.py
+++ b/cakefuzzer/domain/components.py
@@ -271,14 +271,21 @@ class VulnerabilitiesRegistry:
 
     async def get_iteration_result(self, vuln: Vulnerability) -> IterationResult:
         if vuln.iteration_result_id:
-            return await self.iteration_results.get(uid=vuln.iteration_result_id)
+            ir = await self.iteration_results.get(uid=vuln.iteration_result_id)
+
+            if vuln.payload_guid is None or vuln.payload_guid in ir.output.PAYLOAD_GUIDs:
+                return ir
+            
+            return await self.iteration_results.get_by_payload_guid(
+                payload_guid=vuln.payload_guid
+            )
 
         if vuln.payload_guid:
             return await self.iteration_results.get_by_payload_guid(
                 payload_guid=vuln.payload_guid
             )
 
-        print("Vuln None:", vuln)
+        print("Cannot join vulnerability with any iteration result:", vuln)
 
         return None
 

--- a/cakefuzzer/domain/components.py
+++ b/cakefuzzer/domain/components.py
@@ -4,7 +4,7 @@ import time
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiofiles
 from progress.bar import Bar
@@ -212,6 +212,7 @@ async def one_param_per_payload(
 @dataclass
 class FullVulnerability:
     iteration_result: IterationResult
+    found_in_iteration_result: Optional[IterationResult]
     scanner: Scanner
     vulnerability: Vulnerability
     vulnerability_location: Tuple[str]
@@ -269,25 +270,27 @@ class VulnerabilitiesRegistry:
     iteration_results: IterationResultGet
     scanners: ScannerGet
 
-    async def get_iteration_result(self, vuln: Vulnerability) -> IterationResult:
+    async def get_iteration_result(self, vuln: Vulnerability) -> Tuple[IterationResult, IterationResult]:
         if vuln.iteration_result_id:
             ir = await self.iteration_results.get(uid=vuln.iteration_result_id)
 
             if vuln.payload_guid is None or vuln.payload_guid in ir.output.PAYLOAD_GUIDs:
-                return ir
+                return ir, ir
             
-            return await self.iteration_results.get_by_payload_guid(
+            trigger = await self.iteration_results.get_by_payload_guid(
                 payload_guid=vuln.payload_guid
             )
+            return ir, trigger
 
         if vuln.payload_guid:
-            return await self.iteration_results.get_by_payload_guid(
+            trigger = await self.iteration_results.get_by_payload_guid(
                 payload_guid=vuln.payload_guid
             )
+            return trigger, trigger
 
         print("Cannot join vulnerability with any iteration result:", vuln)
 
-        return None
+        return None, None
 
     async def list_all(self) -> List[FullVulnerability]:
         vulns = await self.vulnerabilities.list_all()
@@ -296,18 +299,19 @@ class VulnerabilitiesRegistry:
 
         # Retrieve missing objects
         for vuln in vulns:
-            iteration_result = await self.get_iteration_result(vuln)
+            found_in, triggered_by = await self.get_iteration_result(vuln)
             scanner = await self.scanners.get(uid=vuln.scanner_id)
 
             vulnerability_location = (
                 VulnerabilitiesRegistry.find_vulnerability_location(
-                    iteration_result, vuln.payload_guid
+                    triggered_by, vuln.payload_guid
                 )
             )
 
             full_vulns.append(
                 FullVulnerability(
-                    iteration_result=iteration_result,
+                    iteration_result=triggered_by,
+                    found_in_iteration_result=found_in,
                     scanner=scanner,
                     vulnerability=vuln,
                     vulnerability_location=vulnerability_location,
@@ -414,24 +418,65 @@ class VulnerabilitiesRegistry:
                 }
 
             else:
-                dump_vuln = {
-                    "strategy_name": vuln.iteration_result.scenario.strategy_name,
-                    "payload": payload,
-                    "detection_result": vuln.vulnerability.detection_result,
-                    "context_location": vuln.vulnerability.context_location,
-                    "vulnerability_location": vuln.vulnerability_location,
-                    "vulnerability_id": i,
-                    "path": vuln.iteration_result.output.path,
-                    "method": vuln.iteration_result.output.method,
-                    "superglobal": {
-                        "_GET": vuln.iteration_result.output.GET,
-                        "_POST": vuln.iteration_result.output.POST,
-                        "_REQUEST": vuln.iteration_result.output.REQUEST,
-                        "_COOKIE": vuln.iteration_result.output.COOKIE,
-                        "_FILES": vuln.iteration_result.output.FILES,
-                        "_SERVER": vuln.iteration_result.output.SERVER,
-                    },
-                }
+
+                if vuln.iteration_result == vuln.found_in_iteration_result:
+                    dump_vuln = {
+                        "strategy_name": vuln.iteration_result.scenario.strategy_name,
+                        "payload": payload,
+                        "detection_result": vuln.vulnerability.detection_result,
+                        "context_location": vuln.vulnerability.context_location,
+                        "vulnerability_location": vuln.vulnerability_location,
+                        "vulnerability_id": i,
+                        "path": vuln.iteration_result.output.path,
+                        "method": vuln.iteration_result.output.method,
+                        "superglobal": {
+                            "_GET": vuln.iteration_result.output.GET,
+                            "_POST": vuln.iteration_result.output.POST,
+                            "_REQUEST": vuln.iteration_result.output.REQUEST,
+                            "_COOKIE": vuln.iteration_result.output.COOKIE,
+                            "_FILES": vuln.iteration_result.output.FILES,
+                            "_SERVER": vuln.iteration_result.output.SERVER,
+                        },
+                    }
+                else:
+                    dump_vuln = {
+                        "triggered_by":{
+                            "strategy_name": vuln.iteration_result.scenario.strategy_name,
+                            "payload": payload,
+                            "detection_result": vuln.vulnerability.detection_result,
+                            "context_location": vuln.vulnerability.context_location,
+                            "vulnerability_location": vuln.vulnerability_location,
+                            "vulnerability_id": i,
+                            "path": vuln.iteration_result.output.path,
+                            "method": vuln.iteration_result.output.method,
+                            "superglobal": {
+                                "_GET": vuln.iteration_result.output.GET,
+                                "_POST": vuln.iteration_result.output.POST,
+                                "_REQUEST": vuln.iteration_result.output.REQUEST,
+                                "_COOKIE": vuln.iteration_result.output.COOKIE,
+                                "_FILES": vuln.iteration_result.output.FILES,
+                                "_SERVER": vuln.iteration_result.output.SERVER,
+                            },
+                        },
+                        "found_in":{
+                            "strategy_name": vuln.found_in_iteration_result.scenario.strategy_name,
+                            "payload": vuln.found_in_iteration_result.scenario.payload,
+                            "detection_result": vuln.vulnerability.detection_result,
+                            "context_location": vuln.vulnerability.context_location,
+                            "vulnerability_location": vuln.vulnerability_location,
+                            "vulnerability_id": i,
+                            "path": vuln.found_in_iteration_result.output.path,
+                            "method": vuln.found_in_iteration_result.output.method,
+                            "superglobal": {
+                                "_GET": vuln.found_in_iteration_result.output.GET,
+                                "_POST": vuln.found_in_iteration_result.output.POST,
+                                "_REQUEST": vuln.found_in_iteration_result.output.REQUEST,
+                                "_COOKIE": vuln.found_in_iteration_result.output.COOKIE,
+                                "_FILES": vuln.found_in_iteration_result.output.FILES,
+                                "_SERVER": vuln.found_in_iteration_result.output.SERVER,
+                            },
+                        }
+                    }
 
             dump_vulns.append(dump_vuln)
 

--- a/cakefuzzer/domain/components.py
+++ b/cakefuzzer/domain/components.py
@@ -421,26 +421,7 @@ class VulnerabilitiesRegistry:
 
                 if vuln.iteration_result == vuln.found_in_iteration_result:
                     dump_vuln = {
-                        "strategy_name": vuln.iteration_result.scenario.strategy_name,
-                        "payload": payload,
-                        "detection_result": vuln.vulnerability.detection_result,
-                        "context_location": vuln.vulnerability.context_location,
-                        "vulnerability_location": vuln.vulnerability_location,
-                        "vulnerability_id": i,
-                        "path": vuln.iteration_result.output.path,
-                        "method": vuln.iteration_result.output.method,
-                        "superglobal": {
-                            "_GET": vuln.iteration_result.output.GET,
-                            "_POST": vuln.iteration_result.output.POST,
-                            "_REQUEST": vuln.iteration_result.output.REQUEST,
-                            "_COOKIE": vuln.iteration_result.output.COOKIE,
-                            "_FILES": vuln.iteration_result.output.FILES,
-                            "_SERVER": vuln.iteration_result.output.SERVER,
-                        },
-                    }
-                else:
-                    dump_vuln = {
-                        "triggered_by":{
+                        "found_in": {
                             "strategy_name": vuln.iteration_result.scenario.strategy_name,
                             "payload": payload,
                             "detection_result": vuln.vulnerability.detection_result,
@@ -457,14 +438,30 @@ class VulnerabilitiesRegistry:
                                 "_FILES": vuln.iteration_result.output.FILES,
                                 "_SERVER": vuln.iteration_result.output.SERVER,
                             },
+                        }
+                    }
+                else:
+                    dump_vuln = {
+                        "triggered_by":{
+                            "strategy_name": vuln.iteration_result.scenario.strategy_name,
+                            "payload": payload,
+                            "vulnerability_location": vuln.vulnerability_location,
+                            "vulnerability_id": i,
+                            "path": vuln.iteration_result.output.path,
+                            "method": vuln.iteration_result.output.method,
+                            "superglobal": {
+                                "_GET": vuln.iteration_result.output.GET,
+                                "_POST": vuln.iteration_result.output.POST,
+                                "_REQUEST": vuln.iteration_result.output.REQUEST,
+                                "_COOKIE": vuln.iteration_result.output.COOKIE,
+                                "_FILES": vuln.iteration_result.output.FILES,
+                                "_SERVER": vuln.iteration_result.output.SERVER,
+                            },
                         },
                         "found_in":{
                             "strategy_name": vuln.found_in_iteration_result.scenario.strategy_name,
-                            "payload": vuln.found_in_iteration_result.scenario.payload,
                             "detection_result": vuln.vulnerability.detection_result,
                             "context_location": vuln.vulnerability.context_location,
-                            "vulnerability_location": vuln.vulnerability_location,
-                            "vulnerability_id": i,
                             "path": vuln.found_in_iteration_result.output.path,
                             "method": vuln.found_in_iteration_result.output.method,
                             "superglobal": {

--- a/cakefuzzer/instrumentation/patches/CakePHP/4/FRAMEWORK_PATH/src/ORM/Marshaller.php.patch
+++ b/cakefuzzer/instrumentation/patches/CakePHP/4/FRAMEWORK_PATH/src/ORM/Marshaller.php.patch
@@ -1,0 +1,31 @@
+--- Marshaller.php.orig 2023-07-10 15:30:38.502287826 +0000
++++ Marshaller.php      2023-07-10 15:32:51.557018545 +0000
+@@ -288,15 +288,15 @@
+ 
+         $tableName = $this->_table->getAlias();
+         if (isset($data[$tableName]) && is_array($data[$tableName])) {
+-            $data += $data[$tableName];
++            $data = __cakefuzzer_array_merge($data, $data[$tableName]);
+             unset($data[$tableName]);
+         }
+ 
+-        $data = new ArrayObject($data);
++        // $data = new ArrayObject($data);
+         $options = new ArrayObject($options);
+         $this->_table->dispatchEvent('Model.beforeMarshal', compact('data', 'options'));
+ 
+-        return [(array)$data, (array)$options];
++        return [$data, (array)$options];
+     }
+ 
+     /**
+@@ -560,7 +560,7 @@
+             }
+         }
+ 
+-        $errors = $this->_validate($data + $keys, $options, $isNew);
++        $errors = $this->_validate(__cakefuzzer_array_merge($data, $keys), $options, $isNew);
+         $options['isMerge'] = true;
+         $propertyMap = $this->_buildPropertyMap($data, $options);
+         $properties = [];
+

--- a/strategies/xss.json
+++ b/strategies/xss.json
@@ -1,5 +1,5 @@
 {
-    "strategy_name": "RXSSAttackStrategy",
+    "strategy_name": "XSSAttackStrategy",
     "scenarios": [
         "<script>alert(\"__CAKEFUZZER_XSS_§CAKEFUZZER_PAYLOAD_GUID§__\")</script>",
         "<script>alert('__CAKEFUZZER_XSS_§CAKEFUZZER_PAYLOAD_GUID§__')</script>",


### PR DESCRIPTION
# Description

In order to find vulnerabilities that were triggered by one scenario but found in other requests' response we need to change the way we extract iteration results while building vulnerabilities list. The change is just to check if the payload_guild found in vulnerability is actually coming from the execution that it's linked to, it they are then it's just a standard case for "this request caused this vulnerability" in other case we need to extract different iteration_result (based on the payload_guid because altho we found the vulnerability in this output it was not caused by this request.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Yes, it's simple logical change. 

# Checklist:

- [x] PR title contains the nature of changes (Docs, Feature, Fix, CI, etc.)
- [x] I've set corresponding reviewers, set assignees, and labels.
- [x] My code follows the style guidelines of this project (running `pre-commit`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
