### PR TITLE
Fix&Feature: Scanner & path preparation fix. Magic concatenation support

### DIFF
--- a/cakefuzzer/phpfiles/AppInstrument.php
+++ b/cakefuzzer/phpfiles/AppInstrument.php
@@ -290,6 +290,8 @@ class AppInstrument {
         $fuzz_const = "_CAKE_FUZZER_";
         $pattern = "/${fuzz_const}[a-zA-Z0-9_]+/i";
         $inject = null;
+        $defaults = range(0,100);
+        $defaults = array_merge($defaults, array_fill(0, 200, null));
     
         preg_match_all($pattern, $path, $dynamic_parts);
     
@@ -304,7 +306,7 @@ class AppInstrument {
         $path = str_replace($inject, $selected_payload, $path);
         foreach($dynamic_parts[0] as $dyn_part) {
             if($inject !== $dyn_part) {
-                $path = str_replace($dyn_part, rand(0,100), $path); # TODO: Take this from config maybe?
+                $path = str_replace($dyn_part, $defaults[array_rand($defaults)], $path); # TODO: Take this from config maybe?
             }
         }
     

--- a/cakefuzzer/phpfiles/MagicObjects.php
+++ b/cakefuzzer/phpfiles/MagicObjects.php
@@ -128,17 +128,12 @@ class MagicPayloadDictionary implements JsonSerializable {
         // This is not supported and lacks saving payload first probably
         if(is_string($is_injectable)) return $is_injectable;
 
-        // Draw payload
-        if(is_null($this->_payloads)) {
-            $details = array(
-                'superglobal'=> $this->_superglobal_name,
-                'original' => $this->original,
-                'parameters' => $this->parameters
-            );
-            warning(array(array('error'=>'Superglobal does not have any payloads. This should not happen.', 'details'=>$details)));
-            die;
-        }
+        $payload = $this->_drawPayload();
+        $this->parameters[$key] = $payload;
+        return $payload;
+    }
 
+    protected function _drawPayload() {
         // Draw payload type
         $r = rand() % 5;
         if($this->_prefix !== '') $r = 5; // Assume prefix is only in _SERVER. No arrays there.
@@ -157,7 +152,6 @@ class MagicPayloadDictionary implements JsonSerializable {
             $payload = $this->_replaceDynamic($this->_payloads[array_rand($this->_payloads)]);
         }
 
-        $this->parameters[$key] = $payload;
         return $payload;
     }
 
@@ -253,7 +247,8 @@ class MagicPayloadDictionary implements JsonSerializable {
     }
 
     public function __toString() {
-        return $this->_superglobal_name.'_magic';
+        // return $this->_superglobal_name.'_magic';
+        return $this->_drawPayload();
     }
 }
 

--- a/cakefuzzer/scanners/utils.py
+++ b/cakefuzzer/scanners/utils.py
@@ -67,12 +67,13 @@ class VulnerabilityBuilder:
                 if "CAKEFUZZER_PAYLOAD_GUID" in match.groupdict().keys()
                 else None
             )
+            detection_location = []
             if context_location is not None:
                 locations = find_html_location(self.string, detection_result)
                 detection_location = fnmatch.filter(locations, context_location)
 
             # If the context location is not where it should be, skip it
-            if detection_location is None or detection_location == []:
+            if detection_location == []:
                 continue
 
             vulnerabilities.append(
@@ -100,7 +101,7 @@ class VulnerabilityBuilder:
 def find_html_location(
     contents: str,
     phrase: str,
-) -> None:
+) -> List[str]:
     soup = BeautifulSoup(contents, "html.parser")
     tags = []
     for tag in soup.find_all():


### PR DESCRIPTION
# Description
- Fix `detection_location` in scanners
- Fix path preparation
- Return payload when the Magic object is concatenated with string (like this: `$magic_obj."something"`)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [X] Local VM

**Test Configuration**:
* CakePHP version: 4.4.9
* Application name: Cerebrate
* Application version: 1.14

# Checklist:

- [X] PR title contains the nature of changes (Docs, Feature, Fix, CI, etc.)
- [ ] I've set corresponding reviewers, set assignees, and labels.
- [ ] My code follows the style guidelines of this project (running `pre-commit`)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
