### PR TITLE
Feature: Pass extra web app information from app_info to single_execution

### DIFF
--- a/cake_fuzzer.py
+++ b/cake_fuzzer.py
@@ -312,6 +312,7 @@ async def start_others() -> None:
         app_info = AppInfo(settings.webroot_dir)
         log_paths = await app_info.log_paths
         framework_handler = await app_info.framework_handler
+        extra_app_info = await app_info.extra_app_info
 
         for definition in defs:
             attacks = []
@@ -326,6 +327,7 @@ async def start_others() -> None:
                         path=path,
                         total_iterations=32,
                         payload_guid_phrase=settings.payload_guid_phrase,
+                        extra_app_info=extra_app_info,
                     )
                     for payload, path in itertools.product(
                         definition.scenarios, paths[php_file]
@@ -410,6 +412,7 @@ async def my_start_others() -> None:
         app_info = AppInfo(settings.webroot_dir)
         log_paths = await app_info.log_paths
         framework_handler = await app_info.framework_handler
+        extra_app_info = await app_info.extra_app_info
 
         for definition in defs:
             attacks = []
@@ -424,6 +427,7 @@ async def my_start_others() -> None:
                         path=path,
                         total_iterations=32,
                         payload_guid_phrase=settings.payload_guid_phrase,
+                        extra_app_info=extra_app_info,
                     )
                     for payload, path in itertools.product(
                         definition.scenarios, paths[php_file]

--- a/cakefuzzer/attacks/executor.py
+++ b/cakefuzzer/attacks/executor.py
@@ -50,6 +50,7 @@ class SingleExecutorConfig(BaseModel):
     iterations: int
     PAYLOAD_GUID_phrase: str
     injectable: Optional[Dict[str, str]] = None
+    extra_app_info: Dict = None
 
 
 class IterationResult(BaseModel):
@@ -99,6 +100,7 @@ async def exec_single_executor(
             proc.communicate(input=config.json(by_alias=True).encode("utf8")),
             timeout=10.0,
         )
+
     except TimeoutError:
         print("TimeoutError while waiting for execution to finish", file=sys.stderr)
         print(f"{'Config':-^80}", file=sys.stderr)
@@ -142,6 +144,7 @@ class AttackScenario(BaseModel):
     payload: str
     total_iterations: int
     payload_guid_phrase: str
+    extra_app_info: Dict = None
     # TODO: is that even necessary once oneParamPerPayload goes away?
     injectable: Optional[Dict[str, str]] = None
 
@@ -226,6 +229,7 @@ class AttackScenario(BaseModel):
             iterations=self.total_iterations,
             injectable=self.injectable,
             PAYLOAD_GUID_phrase=self.payload_guid_phrase,
+            extra_app_info=self.extra_app_info,
         )
 
         return config

--- a/cakefuzzer/instrumentation/info_retriever.py
+++ b/cakefuzzer/instrumentation/info_retriever.py
@@ -142,6 +142,16 @@ class AppInfo:
         return Path(output["app_dir"])
 
     @property
+    async def extra_app_info(self) -> Dict:
+        """
+        Call '$ app_info.php get_framework_info json'.
+        """
+        output = await self._call_app_info(["get_framework_info", "json"])
+        if "extra_app_info" in output and output["extra_app_info"]:
+            return output["extra_app_info"]
+        return []
+
+    @property
     async def users(self) -> List[str]:
         """
         Call '$ app_info.php get_users json'.

--- a/cakefuzzer/phpfiles/AppInstrument.php
+++ b/cakefuzzer/phpfiles/AppInstrument.php
@@ -24,6 +24,7 @@ class AppInstrument {
     private $_attack_exclude = array();
     private $_attack_skip_keys = array();
     private $_options = array();
+    private $_extra_app_info = array();
 
     public function __construct($config) {
         global $_CAKEFUZZER_PATH;
@@ -135,6 +136,9 @@ class AppInstrument {
         chdir($this->_web_root); // This is required if the app does "include './file.php'
         
         $this->_webroot_file = $config['webroot_file'];
+
+        if(!empty($config['extra_app_info'])) $this->_extra_app_info = $config['extra_app_info'];
+
         $this->initialize($payloads, $injectable, $targets, $exclude, $fuzz_skip_keys, $options);
     }
 
@@ -171,6 +175,7 @@ class AppInstrument {
 
         // Consider merging this method with AppInfo
         $this->_app_handler = $loader->getAppHandler();
+        $this->_app_handler->SetExtraAppInfo($this->_extra_app_info);
         $this->_app_handler->PrepareFuzzing(); // Prepares framework specific stuff before fuzzing
         return true;
     }

--- a/cakefuzzer/phpfiles/frameworks/FrameworkHandler.php
+++ b/cakefuzzer/phpfiles/frameworks/FrameworkHandler.php
@@ -14,6 +14,7 @@ class FrameworkHandler {
     protected $_app_framework_version = "";
     protected $_app_vars = array();
     protected $_web_root = null;
+    protected $_extra_app_info = array();
     // Manually typed Framework classes used by app_info
     public $required_classes = array();
     public $required_constants = array();
@@ -128,6 +129,13 @@ class FrameworkHandler {
     }
 
     /**
+     * Saves extra information about the application
+     */
+    public function SetExtraAppInfo($extra) {
+        $this->_extra_app_info = $extra;
+    }
+
+    /**
      * Conducts framework custom preparation before fuzzing.
      * To be overwritten by child classes
      *
@@ -174,7 +182,8 @@ class FrameworkHandler {
             'framework_path' => "",
             'framework_version' => $this->_supported_framework_version,
             'app_dir' => "",
-            'app_root_dir' => ""
+            'app_root_dir' => "",
+            'extra_app_info' => $this->_GetExtraAppInfo()
         );
         return $info;
     }
@@ -224,6 +233,14 @@ class FrameworkHandler {
             $paths[$file] = $this->_getPathsForPHPFile($file);
         }
         return $paths;
+    }
+
+    /**
+     * Get additional information about the application.
+     * If necessary this can be overwritten by the specific framework handler.
+     * This information is going to be passed in the get_framework_info app_info command.
+     */
+    protected function _GetExtraAppInfo() {
     }
 
     /**


### PR DESCRIPTION
# Description
That way we can do an automated preparation of web app for further attacks. This could be creating session row in the database and passing it along to single_execution.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* CakePHP version: 
* Application name: 
* Application version: 

# Checklist:

- [X] PR title contains the nature of changes (Docs, Feature, Fix, CI, etc.)
- [ ] I've set corresponding reviewers, set assignees, and labels.
- [ ] My code follows the style guidelines of this project (running `pre-commit`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
